### PR TITLE
Fix circular dependency in predicate handler

### DIFF
--- a/updater/predicate.py
+++ b/updater/predicate.py
@@ -31,7 +31,7 @@ def handle_entity_properties_predicate(predicate: dict):
                 del slot_data["durability"]
 
             if len(predicates.keys()) >= 1:
-                slot_data["predicates"] = slot_data
+                slot_data["predicates"] = predicates
             
     if pred := predicate.get("vehicle"):
         handle_entity_properties_predicate(pred)


### PR DESCRIPTION
The predicate converter had a mistake which caused circular dependencies when saving predicates